### PR TITLE
fix: postQuotes mapping fix

### DIFF
--- a/FSPIOP to ISO 20022 Mapping.md
+++ b/FSPIOP to ISO 20022 Mapping.md
@@ -1,0 +1,264 @@
+# FSPIOP to ISO 20022 payload mapping
+
+## ISO 20022 message version mapping table
+
+| **Resource** | **ISO message** |
+|--- |--- |
+| [**PUT**/parties{Type}/{ID}](#putpartiestypeid--fspiop-to-acmt02400104) | acmt.024.001.04 |
+| [**PUT**/parties{Type}/{ID}/error](#putpartiestypeiderror--fspiop-to-acmt02400104) | acmt.024.001.04 |
+| [**POST**/quotes](#postquotes--fspiop-to-pacs08100101) | pacs.081.001.01 |
+| [**PUT**/quotes/{ID}](#putquotesid--fspiop-to-pacs08200101) | pacs.082.001.01 |
+| [**PUT**/quotes/{ID}/error](#putquotesiderror--fspiop-to-pacs00200115) | pacs.002.001.15 |
+| [**POST**/transfers](#posttransfers--fspiop-to-pacs00800113) | pacs.008.001.13 |
+| [**PATCH**/transfers/{ID}](#patchtransfersid--fspiop-to-pacs00200115) | pacs.002.001.15 |
+| [**PUT**/transfers/{ID}](#puttransfersid--fspiop-to-pacs00200115) | pacs.002.001.15 |
+| [**PUT**/transfers/{ID}/error](#puttransfersiderror--fspiop-to-pacs00200115) | pacs.002.001.15 |
+| [**POST**/fxquotes](#postfxquotes--fspiop-to-pacs09100101) | pacs.091.001.01 |
+| [**PUT**/fxquotes/{ID}](#putfxquotesid--fspiop-to-pacs092001) | pacs.092.001 |
+| [**PUT**/fxquotes/{ID}/error](#putfxquotesiderror--fspiop-to-pacs00200115) | pacs.002.001.15 |
+| [**POST**/fxTransfers](#postfxtransfers--fspiop-to-pacs00900112) | pacs.009.001.12 |
+| [**PUT**/fxTransfers/{ID}](#putfxtransfersid--fspiop-to-pacs00200115) | pacs.002.001.15 |
+| [**PUT**/fxTransfers/{ID}/error](#putfxtransfersiderror--fspiop-to-pacs00200115) | pacs.002.001.15 |
+| [**PATCH**/fxTransfers/{ID}](#patchfxtransfersid--fspiop-to-pacs00200115) | pacs.002.001.15 |
+
+## Detailed Field mapping from FSPIOP to ISO 20022 payloads
+
+### **PUT**/parties{Type}/{ID} : FSPIOP to acmt.024.001.04
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+| TRUE | TRUE | Assgnmt.MsgId | generateID() |
+|  | TRUE | Assgnmt.CreDtTm | datetimeNow() |
+|  | TRUE | Assgnmt.Assgnr.Agt.FinInstnId.Othr.Id | $header.FSPIOP-Source |
+|  | TRUE | Assgnmt.Assgne.Agt.FinInstnId.Othr.Id | $header.FSPIOP-Destination |
+|  | TRUE | Rpt.OrgnlId | {$params.IdPath} |
+|  | TRUE | Rpt.Vrfctn | TRUE |
+| TRUE |  | Rpt.UpdtdPtyAndAcctId.Pty.Id.{PrvId/OrgId}.Othr.SchmeNm.Prtry | if(party.PartyIdInfo.PartyIdType == BUSINESS | party.PartyIdInfo.PartyIdType ==  ALIAS | party.PartyIdInfo.PartyIdType ==  DEVICE)Rpt.UpdtdPtyAndAcctId.Pty.Id.OrgId.Othr.SchmeNm.Prtry = party.partyIdInfo.partyIdTypeelseRpt.UpdtdPtyAndAcctId.Pty.Id.PrvId.Othr.SchmeNm.Prtry = party.partyIdInfo.partyIdType |
+| TRUE |  | Rpt.UpdtdPtyAndAcctId.Pty.Id.{PrvId/OrgId}.Othr.Id | if(party.PartyIdInfo.PartyIdType == BUSINESS | party.PartyIdInfo.PartyIdType ==  ALIAS | party.PartyIdInfo.PartyIdType ==  DEVICE)Rpt.UpdtdPtyAndAcctId.Pty.Id.OrgId.Othr.Id = party.partyIdInfo.partyIdentifierelseRpt.UpdtdPtyAndAcctId.Pty.Id.PrvId.Othr.Id = party.partyIdInfo.partyIdentifier |
+| TRUE |  | Rpt.UpdtdPtyAndAcctId.Agt.FinInstnId.Othr.Id | party.partyIdInfo.fspId |
+| TRUE |  | Rpt.UpdtdPtyAndAcctId.Pty.Nm | party.name |
+| TRUE |  | Rpt.UpdtdPtyAndAcctId.Acct.Ccy | party.supportedCurrencies |
+
+### **PUT**/parties{Type}/{ID}/error : FSPIOP to acmt.024.001.04
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+| TRUE | TRUE | Rpt.Rsn.Cd | errorInformation.errorCode |
+| TRUE | TRUE | Assgnmt.MsgId | $path_params.id |
+|  | TRUE | Assgnmt.CreDtTm | datetimeNow() |
+|  | TRUE | Assgnmt.Assgnr.Agt.FinInstnId.Othr.Id | $header.FSPIOP-Source |
+|  | TRUE | Assgnmt.Assgne.Agt.FinInstnId.Othr.Id | $header.FSPIOP-Destination |
+|  | TRUE | Rpt.OrgnlId | {$params.IdPath} |
+|  | TRUE | Rpt.Vrfctn | FALSE |
+
+
+### **POST**/quotes : FSPIOP to pacs.081.001.01
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+|  | TRUE | GprHdr.NbOfTxs | 1 |
+|  | TRUE | GrpHdr.PmtInstrXpryDtTm | expiration |
+|  | TRUE | GrpHdr.SttlmInf.SttlmMtd | CLRG |
+| TRUE |  | CdtTrfTxInf.PmtId.TxId | quoteId |
+|  |  | CdtTrfTxInf.PmtId.EndToEndId | transactionId |
+|  |  | CdtTrfTxInf.PmtId.InstrId | transactionRequestId |
+| TRUE | TRUE | CdtTrfTxInf.Cdtr.Id.{OrgId/PrvtId}.Othr.SchmeNm.Prtry | if(payee.partyIdInfo.PartyIdType == BUSINESS | payee.partyIdInfo.PartyIdType ==  ALIAS  | payee.partyIdInfo.PartyIdType ==  DEVICE)CdtTrfTxInf.Cdtr.Id.OrgId.Othr.SchmeNm.Prtry = payee.partyIdInfo.partyIdTypeelseCdtTrfTxInf.Cdtr.Id.PrvtId.Othr.SchmeNm.Prtry = payee.partyIdInfo.partyIdType |
+| TRUE | TRUE | CdtTrfTxInf.Cdtr.Id.{OrgId/PrvtId}.Othr.Id | if(payee.PartyIdInfo.PartyIdType == BUSINESS | payee.PartyIdInfo.PartyIdType ==  ALIAS  | payee.PartyIdInfo.PartyIdType ==  DEVICE)CdtTrfTxInf.Cdtr.Id.OrgId.Othr.Id = payee.partyIdInfo.partyIdentifierelseCdtTrfTxInf.Cdtr.Id.PrvtId.Othr.Id = payee.partyIdInfo.partyIdentifier |
+| TRUE | TRUE | CdtTrfTxInf.CdtrAgt.FinInstnId.Othr.Id | payee.partyIdInfo.fspId |
+| TRUE | TRUE | CdtTrfTxInf.Cdtr.Name | payee.name |
+| TRUE |  | CdtTrfTxInf.CdtrAcct.Ccy | payee.supportedCurrencies |
+| TRUE | TRUE | CdtTrfTxInf.Dbtr.Id.{OrgId/PrvtId}.Othr.SchmeNm.Prtry | if(payer.partyIdInfo.PartyIdType == BUSINESS | payer.partyIdInfo.PartyIdType ==  ALIAS  | payer.partyIdInfo.PartyIdType ==  DEVICE)CdtTrfTxInf.Dbtr.Id.OrgId.Othr.SchmeNm.Prtry = payer.partyIdInfo.partyIdTypeelseCdtTrfTxInf.Dbtr.Id.PrvtId.Othr.SchmeNm.Prtry = payer.partyIdInfo.partyIdType |
+| TRUE | TRUE | CdtTrfTxInf.Dbtr.Id.{OrgId/PrvtId}.Othr.Id | if(payer.partyIdInfo.PartyIdType == BUSINESS | payer.partyIdInfo.PartyIdType ==  ALIAS  | payer.partyIdInfo.PartyIdType ==  DEVICE)CdtTrfTxInf.Dbtr.Id.OrgId.Othr.Id = payer.partyIdInfo.partyIdentifierelseCdtTrfTxInf.Dbtr.Id.PrvtId.Othr.Id = payer.partyIdInfo.partyIdentifier |
+| TRUE |  | CdtTrfTxInf.DbtrAgt.FinInstnId.Othr.Id | payer.partyIdInfo.fspId |
+| TRUE | TRUE | CdtTrfTxInf.Dbtr.Name | payer.name |
+| TRUE |  | CdtTrfTxInf.DbtrAcct.Ccy | payer.supportedCurrencies |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.Ccy | amount.currency |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount | amount.amount |
+| TRUE |  | CdtTrfTxInf.ChrgBr | if (amountType=SEND)CdtTrfTxInf.ChrgBr = CREDelse CdtTrfTxInf.ChrgBr = DEBT |
+| TRUE |  | CdtTrfTxInf.Purp.Prtry | transactionType.scenario |
+|  |  | CdtTrfTxInf.PmtId.InstrId | if (transactionType.refundInfo.originalTransactionId)CdtTrfTxInf.PmtId.InstrId = transactionType.refundInfo.originalTransactionId |
+|  |  | CdtTrfTxInf.InstrForCdtrAgt.Cd | If (transactionType.refundInfo)CdtTrfTxInf.InstrForCdtrAgt.Cd = "REFD" |
+|  |  | CdtTrfTxInf.InstrForCdtrAgt.InstrInf | If (transactionType.refundInfo)CdtTrfTxInf.InstrForCdtrAgt.InstrInf = transactionType.refundInfo.reason |
+| TRUE |  | GrpHdr.PmtInstrXpryDtTm | expiration |
+
+### **PUT**/quotes/{ID} : FSPIOP to pacs.082.001.01
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | GrpHdr.PmtId.TxId | $path_params.id |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+|  | TRUE | GprHdr.NbOfTxs | 1 |
+| TRUE |  | GrpHdr.PmtInstrXpryDtTm | expiration |
+|  | TRUE | GrpHdr.SttlmInf.SttlmMtd | CLRG |
+|  | TRUE | CdtTrfTxInf.Dbtr.Id.OrgId.Othr.Id | {$previous.isoPostQuote.CdtTrfTxInf.Dbtr} |
+|  | TRUE | CdtTrfTxInf.DbtrAgt.FinInstnId.Othr.Id | {$previous.isoPostQuote.CdtTrfTxInf.DbtrAgt} |
+|  | TRUE | CdtTrfTxInf.Cdtr.Id.OrgId.Othr.Id | {$previous.isoPostQuote.CdtTrfTxInf.Cdtr} |
+|  | TRUE | CdtTrfTxInf.CdtrAgt.FinInstnId.Othr.Id | {$previous.isoPostQuote.CdtTrfTxInf.CdtrAgt} |
+|  | TRUE | CdtTrfTxInf.ChrgBr | {$previous.isoPostQuote.CdtTrfTxInf.ChrgBr} |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.Ccy | transferAmount.currency |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount | transferAmount.amount |
+|  |  | CdtTrfTxInf.InstdAmt.Ccy | payeeReceiveAmount.currency |
+|  |  | CdtTrfTxInf.InstdAmt.ActiveCurrencyAndAmount | payeeReceiveAmount.amount |
+| TRUE |  | CdtTrfTxInf.ChrgsInf.Amt.Ccy | payeeFspFee.currency |
+| TRUE |  | CdtTrfTxInf.ChrgsInf.Amt.ActiveOrHistoricCurrencyAndAmount | payeeFspFee.amount |
+|  | TRUE | CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id | {$previous.isoPostQuote.CdtTrfTxInf.CdtrAgt} |
+| TRUE |  | CdtTrfTxInf.VrfctnOfTerms.IlpV4PrepPacket | ilpPacket |
+
+### **PUT**/quotes/{ID}/error : FSPIOP to pacs.002.001.15
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+| TRUE |  | TxInfAndSts.StsRsnInf.Rsn.Cd | errorInformation.errorCode |
+
+### **POST**/transfers : FSPIOP to pacs.008.001.13
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+|  | TRUE | GprHdr.NbOfTxs | 1 |
+| TRUE | TRUE | GrpHdr.PmtInstrXpryDtTm | expiration |
+|  | TRUE | GrpHdr.SttlmInf.SttlmMtd | CLRG |
+|  | TRUE | CdtTrfTxInf.ChrgBr | {$previous.postQuoteResponse.CdtTrfTxInf.ChrgBr} |
+|  | TRUE | CdtTrfTxInf.Cdtr | {$previous.postQuoteResponse.CdtTrfTxInf.Cdtr} |
+|  | TRUE | CdtTrfTxInf.Dbtr | {$previous.postQuoteResponse.CdtTrfTxInf.Dbtr} |
+| TRUE |  | CdtTrfTxInf.PmtId.TxId | transferId |
+| TRUE |  | CdtTrfTxInf.CdtrAgt.FinInstnId.Othr.Id | payeeFsp |
+| TRUE |  | CdtTrfTxInf.DbtrAgt.FinInstnId.Othr.Id | payerFsp |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.Ccy | amount.currency |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount | amount.amount |
+| TRUE |  | CdtTrfTxInf.VrfctnOfTerms.IlpV4PrepPacket | ilpPacket |
+
+### **PATCH**/transfers/{ID} : FSPIOP to pacs.002.001.15
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+| TRUE |  | TxInfAndSts.PrcgDt.DtTm | completedTimestamp |
+| TRUE |  | TxInfAndSts.TxSts | transferState |
+
+### **PUT**/transfers/{ID} : FSPIOP to pacs.002.001.15
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+| TRUE |  | TxInfAndSts.ExctnConf | fulfilment |
+| TRUE |  | TxInfAndSts.PrcgDt.DtTm | completedTimestamp |
+| TRUE |  | TxInfAndSts.TxSts | transferState |
+
+### **PUT**/transfers/{ID}/error : FSPIOP to pacs.002.001.15
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+| TRUE |  | TxInfAndSts.StsRsnInf.Rsn.Cd | errorInformation.errorCode |
+
+### **POST**/fxquotes : FSPIOP to pacs.091.001.01
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+|  | TRUE | GprHdr.NbOfTxs | 1 |
+| TRUE |  | GrpHdr.PmtInstrXpryDtTm | expiration |
+|  | TRUE | GrpHdr.SttlmInf.SttlmMtd | CLRG |
+| TRUE |  | CdtTrfTxInf.PmtId.TxId | conversionRequestId |
+| TRUE |  | CdtTrfTxInf.PmtId.InstrId | conversionTerms.conversionId |
+| TRUE |  | CdtTrfTxInf.PmtId.EndToEndId  | conversionTerms.determiningTransferId |
+| TRUE |  | CdtTrfTxInf.Dbtr.FinInstnId.Othr.Id | conversionTerms.initiatingFsp |
+| TRUE |  | CdtTrfTxInf.Cdtr.FinInstnId.Othr.Id | conversionTerms.counterPartyFsp |
+| TRUE |  | CdtTrfTxInf.InstrForCdtrAgt.InstrInf | conversionTerms.amountType |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.Dbtr.OrgId.Othr.Id.Prtry | conversionTerms.initiatingFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.DbtrAgt.FinInstnId.Othr.Id | conversionTerms.initiatingFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.Cdtr.OrgId.Othr.Id.Prtry | conversionTerms.counterPartyFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.CdtrAgt.FinInstnId.Othr.Id | conversionTerms.counterPartyFsp |
+| TRUE |  | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.Ccy | conversionTerms.sourceAmount.currency |
+| TRUE |  | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.ActiveOrHistoricCurrencyAndAmount | conversionTerms.sourceAmount.amount |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.Ccy | conversionTerms.targetAmount.currency |
+|  | TRUE | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount | 0 |
+
+### **PUT**/fxquotes/{ID} : FSPIOP to pacs.092.001
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | CdtTrfTxInf.VrfctnOfTerms.Sh256Sgntr | condition |
+| TRUE |  | CdtTrfTxInf.VrfctnOfTerms.PmtId.InstrId | conversionTerms.conversionId |
+| TRUE |  | CdtTrfTxInf.PmtId.TxId | conversionTerms.determiningTransferId |
+| TRUE |  | CdtTrfTxInf.Dbtr.FinInstnId.Othr.Id | conversionTerms.initiatingFsp |
+| TRUE |  | CdtTrfTxInf.Cdtr.FinInstnId.Othr.Id | conversionTerms.counterPartyFsp |
+| TRUE |  | CdtTrfTxInf.InstrForCdtrAgt.InstrInf | conversionTerms.amountType |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.Dbtr.OrgId.Othr.Id.Prtry | conversionTerms.initiatingFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.DbtrAgt.FinInstnId.Othr.Id | conversionTerms.initiatingFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.Cdtr.OrgId.Othr.Id.Prtry | conversionTerms.counterPartyFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.CdtrAgt.FinInstnId.Othr.Id | conversionTerms.counterPartyFsp |
+| TRUE |  | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.Ccy | conversionTerms.sourceAmount.currency |
+| TRUE |  | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.ActiveOrHistoricCurrencyAndAmount | conversionTerms.sourceAmount.amount |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.Ccy | conversionTerms.targetAmount.currency |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount | conversionTerms.targetAmount.amount |
+| TRUE |  | GrpHdr.PmtInstrXpryDtTm | conversionTerms.expiration |
+
+### **PUT**/fxquotes/{ID}/error : FSPIOP to pacs.002.001.15
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+| TRUE |  | TxInfAndSts.StsRsnInf.Rsn.Cd | errorInformation.errorCode |
+
+### **POST**/fxTransfers : FSPIOP to pacs.009.001.12
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+|  | TRUE | GprHdr.NbOfTxs | 1 (For now, bulk TBD) |
+| TRUE |  | GrpHdr.PmtInstrXpryDtTm | expiration |
+|  | TRUE | GrpHdr.SttlmInf.SttlmMtd | CLRG |
+| TRUE |  | CdtTrfTxInf.PmtId.TxId | commitRequestId |
+| TRUE |  | CdtTrfTxInf.PmtId.EndToEndId | determiningTransferId |
+| TRUE |  | CdtTrfTxInf.Dbtr.FinInstnId.Othr.Id | initiatingFsp |
+| TRUE |  | CdtTrfTxInf.Cdtr.FinInstnId.Othr.Id | counterPartyFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.Dbtr.Id.OrgId.Othr.Id | initiatingFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.DbtrAgt.FinInstnId.Othr.Id | initiatingFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.Cdtr.Id.OrgId.Othr.Id | counterPartyFsp |
+|  | TRUE | CdtTrfTxInf.UndrlygCstmrCdtTrf.CdtrAgt.FinInstnId.Othr.Id | counterPartyFsp |
+| TRUE |  | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.Ccy | sourceAmount.currency |
+| TRUE |  | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.ActiveOrHistoricCurrencyAndAmount | sourceAmount.amount |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.Ccy | targetAmount.currency |
+| TRUE |  | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount | targetAmount.amount |
+| TRUE |  | CdtTrfTxInf.VrfctnOfTerms.Sh256Sgntr | condition |
+
+### **PUT**/fxTransfers/{ID} : FSPIOP to pacs.002.001.15
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+| TRUE |  | TxInfAndSts.ExctnConf | fulfilment |
+| TRUE |  | TxInfAndSts.PrcgDt.DtTm | completedTimestamp |
+| TRUE |  | TxInfAndSts.TxSts | transferState |
+
+### **PUT**/fxTransfers/{ID}/error : FSPIOP to pacs.002.001.15
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+|  |  | TxInfAndSts.StsRsnInf.Rsn.Cd | errorInformation.errorCode |
+
+### **PATCH**/fxTransfers/{ID} : FSPIOP to pacs.002.001.15
+
+| Required by FSPIOP | Required by ISO 20022 | ISO20022 Field | FSPIOP Mapping |
+|--- |--- |--- |--- |
+|  | TRUE | GrpHdr.MsgId | generateID() |
+|  | TRUE | GrpHdr.CreDtTm | datetimeNow() |
+| TRUE |  | TxInfAndSts.PrcgDt.DtTm  | completedTimestamp |
+| TRUE |  | TxInfAndSts.TxSts | transferState |

--- a/ISO 20022 to FSPIOP Mapping.md
+++ b/ISO 20022 to FSPIOP Mapping.md
@@ -1,0 +1,206 @@
+# ISO 20022 to FSPIOP payload mapping
+
+## ISO 20022 message version mapping table
+
+| **Resource** | **ISO message** |
+|--- |--- |
+| [**PUT**/parties{Type}/{ID}](#putpartiestypeid--acmt02400104-to-fspiop) | acmt.024.001.04 |
+| [**PUT**/parties{Type}/{ID}/error](#putpartiestypeiderror--acmt02400104-to-fspiop) | acmt.024.001.04 |
+| [**POST**/quotes](#postquotes--pacs08100101-to-fspiop) | pacs.081.001.01 |
+| [**PUT**/quotes/{ID}](#putquotesid--pacs08200101-to-fspiop) | pacs.082.001.01 |
+| [**PUT**/quotes/{ID}/error](#putquotesiderror--pacs00200115-to-fspiop) | pacs.002.001.15 |
+| [**POST**/transfers](#posttransfers--pacs00800113-to-fspiop) | pacs.008.001.13 |
+| [**PATCH**/transfers/{ID}](#patchtransfersid--pacs00200115-to-fspiop) | pacs.002.001.15 |
+| [**PUT**/transfers/{ID}](#puttransfersid--pacs00200115-to-fspiop) | pacs.002.001.15 |
+| [**PUT**/transfers/{ID}/error](#puttransfersiderror--pacs00200115-to-fspiop) | pacs.002.001.15 |
+| [**POST**/fxquotes](#postfxquotes--pacs09100101-to-fspiop) | pacs.091.001.01 |
+| [**PUT**/fxquotes/{ID}](#putfxquotesid--pacs092001-to-fspiop) | pacs.092.001 |
+| [**PUT**/fxquotes/{ID}/error](#putfxquotesiderror--pacs00200115-to-fspiop) | pacs.002.001.15 |
+| [**POST**/fxTransfers](#postfxtransfers--pacs00900112-to-fspiop) | pacs.009.001.12 |
+| [**PUT**/fxTransfers/{ID}](#putfxtransfersid--pacs00200115-to-fspiop) | pacs.002.001.15 |
+| [**PUT**/fxTransfers/{ID}/error](#putfxtransfersiderror--pacs00200115-to-fspiop) | pacs.002.001.15 |
+| [**PATCH**/fxTransfers/{ID}](#patchfxtransfersid--pacs00200115-to-fspiop) | pacs.002.001.15 |
+
+## Detailed Field mapping from ISO 20022 to FSPIOP payloads
+
+### **PUT**/parties{Type}/{ID} : acmt.024.001.04 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | party.partyIdInfo.partyIdType | if(Rpt.UpdtdPtyAndAcctId.Pty.Id.OrgId.Othr.SchmeNm.Prtry)party.partyIdInfo.partyIdType = Rpt.UpdtdPtyAndAcctId.Pty.Id.OrgId.Othr.SchmeNm.Prtryelse if(Rpt.UpdtdPtyAndAcctId.Pty.Id.PrvtId.Othr.SchmeNm.Prtry)party.partyIdInfo.partyIdType = Rpt.UpdtdPtyAndAcctId.Pty.Id.PrvtId.Othr.SchmeNm.Prtryelseparty.partyIdInfo.partyIdType = Rpt.UpdtdPtyAndAcctId.Pty.PrvtId.Othr.Id |
+| TRUE |  | party.partyIdInfo.partyIdentifier | if(Rpt.UpdtdPtyAndAcctId.Pty.Id.OrgId.Othr.Id)party.partyIdInfo.partyIdentifier = Rpt.UpdtdPtyAndAcctId.Pty.Id.OrgId.Othr.Idelse party.partyIdInfo.partyIdentifier = Rpt.UpdtdPtyAndAcctId.Pty.Id.PrvtId.Othr.Id |
+| TRUE |  | party.partyIdInfo.fspId | Rpt.UpdtdPtyAndAcctId.Agt.FinInstnId.Othr.Id |
+| TRUE |  | party.name | Rpt.UpdtdPtyAndAcctId.Pty.Nm |
+| TRUE |  | party.supportedCurrencies | Rpt.UpdtdPtyAndAcctId.Acct.Ccy |
+
+### **PUT**/parties{Type}/{ID}/error : acmt.024.001.04 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | errorInformation.errorCode | Rpt.Rsn.Cd |
+| Non-Critical |  | errorInformation.errorDescription | getDescriptionfromCode(Rpt.Rsn.Cd) |
+|  | TRUE | generateID() | Assgnmt.MsgId |
+|  | TRUE | datetimeNow() | Assgnmt.CreDtTm |
+|  |  | $header.FSPIOP-Source | Assgnmt.Assgnr.Agt.FinInstnId.Othr.Id |
+|  |  | $header.FSPIOP-Destination | Assgnmt.Assgne.Agt.FinInstnId.Othr.Id |
+|  |  | $params.IdPath | Rpt.OrgnlId |
+
+### **POST**/quotes : pacs.081.001.01 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | quoteId | CdtTrfTxInf.PmtId.TxId |
+| TRUE |  | expiration | GrpHdr.PmtInstrXpryDtTm |
+|  |  | transactionId | CdtTrfTxInf.PmtId.EndToEndId |
+|  |  | transactionRequestId | CdtTrfTxInf.PmtId.InstrId |
+| TRUE |  | payee.partyIdInfo.partyIdType | if(CdtTrfTxInf.Cdtr.Id.OrgId.Othr.SchmeNm.Prtry)payee.partyIdInfo.partyIdType = CdtTrfTxInf.Cdtr.Id.OrgId.Othr.SchmeNm.Prtryelsepayee.partyIdInfo.partyIdType = CdtTrfTxInf.Cdtr.Id.PrvtId.Othr.SchmeNm.Prtry |
+| TRUE |  | payee.partyIdInfo.partyIdentifier | if(CdtTrfTxInf.Cdtr.Id.OrgId.Othr.Id)payee.partyIdInfo.partyIdentifier = CdtTrfTxInf.Cdtr.Id.OrgId.Othr.Idelsepayee.partyIdInfo.partyIdentifier = CdtTrfTxInf.Cdtr.Id.PrvtId.Othr.Id |
+| TRUE |  | payee.partyIdInfo.fspId | CdtTrfTxInf.CdtrAgt.FinInstnId.Othr.Id |
+| TRUE |  | payee.name | CdtTrfTxInf.Cdtr.Name |
+| TRUE |  | payee.supportedCurrencies | CdtTrfTxInf.CdtrAcct.Ccy |
+| TRUE |  | payer.partyIdInfo.partyIdType | if(CdtTrfTxInf.Dbtr.Id.OrgId.Othr.SchmeNm.Prtry)payer.partyIdInfo.partyIdType = CdtTrfTxInf.Dbtr.Id.OrgId.Othr.SchmeNm.Prtryelsepayer.partyIdInfo.partyIdType = CdtTrfTxInf.Dbtr.Id.PrvtId.Othr.SchmeNm.Prtry |
+| TRUE |  | payer.partyIdInfo.partyIdentifier | if(CdtTrfTxInf.Dbtr.Id.OrgId.Othr.Id)payer.partyIdInfo.partyIdentifier = CdtTrfTxInf.Dbtr.Id.OrgId.Othr.Idelsepayer.partyIdInfo.partyIdentifier = CdtTrfTxInf.Dbtr.Id.PrvtId.Othr.Id |
+| TRUE |  | payer.partyIdInfo.fspId | CdtTrfTxInf.DbtrAgt.FinInstnId.Othr.Id |
+| TRUE |  | payer.name | CdtTrfTxInf.Dbtr.Name |
+| TRUE |  | payer.supportedCurrencies | CdtTrfTxInf.DbtrAcct.Ccy |
+| TRUE |  | amount.currency | CdtTrfTxInf.IntrBkSttlmAmt.Ccy |
+| TRUE |  | amount.amount | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount |
+| TRUE |  | amountType | if (CdtTrfTxInf.ChrgBr=DEBT)amountType = RECEIVEelse amountType = SEND |
+| TRUE |  | transactionType.scenario | CdtTrfTxInf.Purp.Prtry |
+| TRUE |  | transactionType.initiator | if (CdtTrfTxInf.PmtId.InstrId is null)"PAYER"else"PAYEE" |
+| TRUE |  | transactionType.initiatorType | if (CdtTrfTxInf.PmtId.InstrId is null){  if(CdtTrfTxInf.Dtr.Id.Pty)     transactionType.initiatorType='CONSUMER'  else    transactionType.initiatorType='BUSINESS'}else {  if(CdtTrfTxInf.Cdr.Id.Pty)     transactionType.initiatorType='CONSUMER'  else    transactionType.initiatorType='BUSINESS'} |
+|  |  | transactionType.refundInfo.originalTransactionId | if(CdtTrfTxInf.PmtId.InstrId)transactionType.refundInfo.originalTransactionId = CdtTrfTxInf.PmtId.InstrId |
+|  |  | transactionType.refundInfo.refundReason | If (CdtTrfTxInf.InstrForCdtrAgt.Cd == REFD)CdtTrfTxInf.InstrForCdtrAgt.InstrInf = transactionType.refundInfo.reason |
+
+### **PUT**/quotes/{ID} : pacs.082.001.01 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+|  |  | {$headers[fspiop-destination]} | CdtTrfTxInf.Dbtr.Id.OrgId.Othr.Id |
+|  |  | {$headers[fspiop-source] | CdtTrfTxInf.Cdtr.Id.OrgId.Othr.Id |
+| TRUE |  | expiration | GrpHdr.PmtInstrXpryDtTm |
+| TRUE |  | transferAmount.currency | CdtTrfTxInf.IntrBkSttlmAmt.Ccy |
+| TRUE |  | transferAmount.amount | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount |
+|  |  | payeeReceiveAmount.currency | CdtTrfTxInf.InstdAmt.Ccy |
+|  |  | payeeReceiveAmount.amount | CdtTrfTxInf.InstdAmt.ActiveCurrencyAndAmount |
+|  |  | payeeFspFee.currency | CdtTrfTxInf.ChrgsInf.Amt.Ccy |
+|  |  | payeeFspFee.amount | CdtTrfTxInf.ChrgsInf.Amt.ActiveOrHistoricCurrencyAndAmount |
+| TRUE |  | ilpPacket | CdtTrfTxInf.VrfctnOfTerms.IlpV4PrepPacket |
+| TRUE |  | condition | condition = decodeAndGetConditionFromIlp(CdtTrfTxInf.VrfctnOfTerms.IlpV4PrepPacket) |
+
+### **PUT**/quotes/{ID}/error : pacs.002.001.15 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | errorInformation.errorCode | TxInfAndSts.StsRsnInf.Rsn.Cd |
+|  |  | errorInformation.errorDescription | getDescriptionfromCode(TxInfAndSts.StsRsnInf.Rsn.Cd) |
+
+### **POST**/transfers : pacs.008.001.13 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | expiration | GrpHdr.PmtInstrXpryDtTm |
+| TRUE |  | transferId | CdtTrfTxInf.PmtId.TxId |
+| TRUE |  | payeeFsp | CdtTrfTxInf.CdtrAgt.FinInstnId.Othr.Id |
+| TRUE |  | payerFsp | CdtTrfTxInf.DbtrAgt.FinInstnId.Othr.Id |
+| TRUE |  | amount.currency | CdtTrfTxInf.IntrBkSttlmAmt.Ccy |
+| TRUE |  | amount.amount | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount |
+| TRUE |  | ilpPacket | CdtTrfTxInf.VrfctnOfTerms.IlpV4PrepPacket |
+| TRUE |  | condition | condition = decodeAndGetConditionFromIlp(CdtTrfTxInf.VrfctnOfTerms.IlpV4PrepPacket) |
+
+### **PATCH**/transfers/{ID} : pacs.002.001.15 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | completedTimestamp | TxInfAndSts.PrcgDt.DtTm |
+| TRUE |  | transferState | toFSPIOPTransferState(TxInfAndSts.TxSts) |
+
+### **PUT**/transfers/{ID} : pacs.002.001.15 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | fulfilment | TxInfAndSts.ExctnConf |
+| TRUE |  | completedTimestamp | TxInfAndSts.PrcgDt.DtTm |
+| TRUE |  | transferState | toFSPIOPTransferState(TxInfAndSts.TxSts) |
+
+### **PUT**/transfers/{ID}/error : pacs.002.001.15 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | errorInformation.errorCode | TxInfAndSts.StsRsnInf.Rsn.Cd |
+|  |  | errorInformation.errorDescription | getDescriptionfromCode(TxInfAndSts.StsRsnInf.Rsn.Cd) |
+
+### **POST**/fxquotes : pacs.091.001.01 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | conversionTerms.expiration | GrpHdr.PmtInstrXpryDtTm |
+| TRUE |  | conversionRequestId | CdtTrfTxInf.PmtId.TxId |
+| TRUE |  | conversionTerms.conversionId | CdtTrfTxInf.PmtId.InstrId |
+| TRUE |  | conversionTerms.determiningTransferId | CdtTrfTxInf.PmtId.EndToEndId  |
+| TRUE |  | conversionTerms.initiatingFsp | CdtTrfTxInf.Dbtr.FinInstnId.Othr.Id |
+| TRUE |  | conversionTerms.counterPartyFsp | CdtTrfTxInf.Cdtr.FinInstnId.Othr.Id |
+| TRUE |  | conversionTerms.amountType | CdtTrfTxInf.InstrForCdtrAgt.InstrInf |
+| TRUE |  | conversionTerms.sourceAmount.currency | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.Ccy |
+| TRUE |  | conversionTerms.sourceAmount.amount | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.ActiveOrHistoricCurrencyAndAmount |
+| TRUE |  | conversionTerms.targetAmount.currency | CdtTrfTxInf.IntrBkSttlmAmt.Ccy |
+
+### **PUT**/fxquotes/{ID} : pacs.092.001 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | condition | CdtTrfTxInf.VrfctnOfTerms.Sh256Sgntr |
+| TRUE |  | conversionTerms.conversionId | CdtTrfTxInf.VrfctnOfTerms.PmtId.InstrId |
+| TRUE |  | conversionTerms.determiningTransferId | CdtTrfTxInf.PmtId.TxId |
+| TRUE |  | conversionTerms.initiatingFsp | CdtTrfTxInf.Dbtr.FinInstnId.Othr.Id |
+| TRUE |  | conversionTerms.counterPartyFsp | CdtTrfTxInf.Cdtr.FinInstnId.Othr.Id |
+| TRUE |  | conversionTerms.amountType | CdtTrfTxInf.InstrForCdtrAgt.InstrInf |
+| TRUE |  | conversionTerms.sourceAmount.currency | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.Ccy |
+| TRUE |  | conversionTerms.sourceAmount.amount | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.ActiveOrHistoricCurrencyAndAmount |
+| TRUE |  | conversionTerms.targetAmount.currency | CdtTrfTxInf.IntrBkSttlmAmt.Ccy |
+| TRUE |  | conversionTerms.targetAmount.amount | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount |
+| TRUE |  | conversionTerms.expiration | GrpHdr.PmtInstrXpryDtTm |
+
+### **PUT**/fxquotes/{ID}/error : pacs.002.001.15 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | errorInformation.errorCode | TxInfAndSts.StsRsnInf.Rsn.Cd |
+|  |  | errorInformation.errorDescription | getDescriptionfromCode(TxInfAndSts.StsRsnInf.Rsn.Cd) |
+
+### **POST**/fxTransfers : pacs.009.001.12 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | expiration | GrpHdr.PmtInstrXpryDtTm |
+| TRUE |  | commitRequestId | CdtTrfTxInf.PmtId.TxId |
+| TRUE |  | determiningTransferId | CdtTrfTxInf.PmtId.EndToEndId |
+| TRUE |  | initiatingFsp | CdtTrfTxInf.Dbtr.FinInstnId.Othr.Id |
+| TRUE |  | counterPartyFsp | CdtTrfTxInf.Cdtr.FinInstnId.Othr.Id |
+| TRUE |  | sourceAmount.currency | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.Ccy |
+| TRUE |  | sourceAmount.amount | CdtTrfTxInf.UndrlygCstmrCdtTrf.InstdAmt.ActiveOrHistoricCurrencyAndAmount |
+| TRUE |  | targetAmount.currency | CdtTrfTxInf.IntrBkSttlmAmt.Ccy |
+| TRUE |  | targetAmount.amount | CdtTrfTxInf.IntrBkSttlmAmt.ActiveCurrencyAndAmount |
+| TRUE |  | condition | CdtTrfTxInf.VrfctnOfTerms.Sh256Sgntr |
+
+### **PUT**/fxTransfers/{ID} : pacs.002.001.15 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | fulfilment | TxInfAndSts.ExctnConf |
+| TRUE |  | completedTimestamp | TxInfAndSts.PrcgDt.DtTm |
+| TRUE |  | transferState | toFSPIOPTransferState(TxInfAndSts.TxSts) |
+
+### **PUT**/fxTransfers/{ID}/error : pacs.002.001.15 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | errorInformation.errorCode | TxInfAndSts.StsRsnInf.Rsn.Cd |
+|  |  | errorInformation.errorDescription | getDescriptionfromCode(TxInfAndSts.StsRsnInf.Rsn.Cd) |
+
+### **PATCH**/fxTransfers/{ID} : pacs.002.001.15 to FSPIOP
+
+| Required by FSPIOP | Required by ISO 20022 | FSPIOP Field | ISO20022 Mapping |
+|--- |--- |--- |--- |
+| TRUE |  | completedTimestamp | TxInfAndSts.PrcgDt.DtTm  |
+| TRUE |  | transferState | toFSPIOPTransferState(TxInfAndSts.TxSts) |

--- a/src/facades/fspiop.ts
+++ b/src/facades/fspiop.ts
@@ -134,7 +134,7 @@ export const FspiopTransformFacade = {
       }) as IsoTarget;
 
       if (!source.body.payeeFspFee && hasProp(target, 'body.CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id')) {
-        delete target.body.CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id;
+        delete target.body.CdtTrfTxInf.ChrgsInf;
       }
 
       return target;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -85,6 +85,22 @@ export const getProp = (obj: unknown, path: string): unknown  => {
   return current;
 }
 
+// Safely check if nested property exists in an object
+export const hasProp = (obj: unknown, path: string): boolean => {
+  const pathParts = path.split('.');
+  let current = obj;
+
+  for (const part of pathParts) {
+    if (typeof current === 'object' && current !== null && part in current) {
+      current = (current as GenericObject)[part];
+    } else {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export const getDescrForErrCode = (code: string | number): string => {
   try {
     const errorCode = Number.parseInt(code as string);

--- a/test/unit/facades/fspiop.test.ts
+++ b/test/unit/facades/fspiop.test.ts
@@ -201,6 +201,13 @@ describe('FSPIOPTransformFacade tests', () => {
         expect(getProp(target, 'body.CdtTrfTxInf.CdtrAgt.FinInstnId.Othr.Id')).toBe('CdtrAgt');
         expect(getProp(target, 'body.CdtTrfTxInf.ChrgBr')).toBe('ChrgBr');
       });
+      test('should remove body.CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id in target if body.payeeFspFee  not set in source', async () => {
+        const source = { ...fspiopSources.quotes.put };
+        delete (source as any).body.payeeFspFee;
+        const target = await FspiopTransformFacade.quotes.put(source);
+        expect(target).toHaveProperty('body');
+        expect(getProp(target, 'body.CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id')).toBeUndefined();
+      })
     });
     describe('PUT /quotes/{ID}/error', () => {
       test('should throw if source is wrongly typed', async () => {

--- a/test/unit/facades/fspiop.test.ts
+++ b/test/unit/facades/fspiop.test.ts
@@ -201,7 +201,7 @@ describe('FSPIOPTransformFacade tests', () => {
         expect(getProp(target, 'body.CdtTrfTxInf.CdtrAgt.FinInstnId.Othr.Id')).toBe('CdtrAgt');
         expect(getProp(target, 'body.CdtTrfTxInf.ChrgBr')).toBe('ChrgBr');
       });
-      test('should remove body.CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id in target if body.payeeFspFee  not set in source', async () => {
+      test('should remove body.CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id in target if body.payeeFspFee not set in source', async () => {
         const source = { ...fspiopSources.quotes.put };
         delete (source as any).body.payeeFspFee;
         const target = await FspiopTransformFacade.quotes.put(source);

--- a/test/unit/facades/fspiop.test.ts
+++ b/test/unit/facades/fspiop.test.ts
@@ -201,12 +201,12 @@ describe('FSPIOPTransformFacade tests', () => {
         expect(getProp(target, 'body.CdtTrfTxInf.CdtrAgt.FinInstnId.Othr.Id')).toBe('CdtrAgt');
         expect(getProp(target, 'body.CdtTrfTxInf.ChrgBr')).toBe('ChrgBr');
       });
-      test('should remove body.CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id in target if body.payeeFspFee not set in source', async () => {
+      test('should remove body.CdtTrfTxInf.ChrgsInf in target if body.payeeFspFee not set in source', async () => {
         const source = { ...fspiopSources.quotes.put };
         delete (source as any).body.payeeFspFee;
         const target = await FspiopTransformFacade.quotes.put(source);
         expect(target).toHaveProperty('body');
-        expect(getProp(target, 'body.CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id')).toBeUndefined();
+        expect(getProp(target, 'body.CdtTrfTxInf.ChrgsInf')).toBeUndefined();
       })
     });
     describe('PUT /quotes/{ID}/error', () => {


### PR DESCRIPTION
 Removes `CdtTrfTxInf.ChrgsInf.Agt.FinInstnId.Othr.Id` if `payeeFspFee` is not set